### PR TITLE
Add transcript of steps necessary to build on Xen.

### DIFF
--- a/Get Started
+++ b/Get Started
@@ -24,6 +24,45 @@ make
 A server will be launched using the specified URL as the git remote, `Index` as the default page rendered on the blog (it must exist within the repository) and `8080` is the listening port.
 You can see more options by running `./mir-canopy --help`.
 
+### Compiling and running on Xen
+
+If you want to build for xen, there's a couple of packages that need to be
+installed from specific branches.
+
+```sh
+opam pin add dolog 'https://github.com/UnixJunkie/dolog.git#no_unix'
+opam pin add decompress 'https://github.com/oklm-wsh/Decompress.git'
+opam pin add bin_prot 'https://github.com/samoht/bin_prot.git#112.35.00+xen'
+opam pin add crc 'https://github.com/yomimono/ocaml-crc.git#xen_linkopts'
+```
+
+You can either build with support for DHCP or static ip, just specifying it in an
+environment variable, for instance:
+
+```sh
+DHCP='no' mirage configure --xen
+make
+```
+
+Make sure to have `br0` set up for this. For example, I did:
+
+```
+# provide ip forwarding
+echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.conf
+sysctl -p /etc/sysctl.conf
+iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
+# create a new bridge
+brctl addbr br0
+ip addr dev br0 add 10.0.0.1/24
+ip link set br0 up
+```
+
+Finally you can run your unikernel!
+
+```sh
+xl create -c canopy.xl
+```
+
 ### Git push hooks
 
 To keep your Canopy content updated, you need to tell your instance that new content is available on the git remote, then it will just pull the changes and will serve the new content.


### PR DESCRIPTION
XXX: there is no `sudo`, so it's not explicit what needs getuid() == 0;
XXX: it has not been fully reproduced.
